### PR TITLE
Set fb_auth.ini ownership and access rights

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,6 +16,8 @@ test: clean
 install: compile
 	sudo cp fb_auth.beam $(COUCHDB_ERLANG_LIB)/ebin/
 	sudo cp fb_auth.ini $(COUCHDB_LOCALD)
+	sudo chown root:couchdb $(COUCHDB_LOCALD)/fb_auth.ini
+	sudo chmod 660 $(COUCHDB_LOCALD)/fb_auth.ini
 	sudo /etc/init.d/couchdb restart
 
 compile: clean

--- a/fb_auth.erl
+++ b/fb_auth.erl
@@ -223,7 +223,7 @@ process_facebook_access_token(Resp) ->
     % Extract the info we need
     case Resp of 
         {ok, {{_,200,_}, _, Body}} ->
-            case string:tokens(Body, "=") of
+            case string:tokens(Body, "=&") of
                 ["access_token", AccessToken] ->
                     ?LOG_DEBUG("process_facebook_access_token: access_token=~p",[AccessToken]),
                     {ok, AccessToken};

--- a/fb_auth.erl
+++ b/fb_auth.erl
@@ -227,6 +227,9 @@ process_facebook_access_token(Resp) ->
                 ["access_token", AccessToken] ->
                     ?LOG_DEBUG("process_facebook_access_token: access_token=~p",[AccessToken]),
                     {ok, AccessToken};
+                ["access_token", AccessToken, "expires", Expires] ->
+                    ?LOG_DEBUG("process_facebook_access_token: access_token=~p",[AccessToken]),
+                    {ok, AccessToken};
                 _ ->
                     ?LOG_DEBUG("process_facebook_access_token: unexpected response: ~p", [Body]),
                     {error, "Unexpected body response from facebook"}


### PR DESCRIPTION
Hi Martin.

First of all take the biggest thanks ever for such a great couch db extension. Since I'm not experienced with Erlang you saved me a lot of time. Thanks.

Secondly, I've spent something around a half an hour to figure out why it doesn't work, and even hangs down my couchdb instance. God, please send a curse to that Erlang logging style :) The reason was in wrong ownership/mode bits of fb_auth.ini, so I added little fix into your Makefile.

Please check it out.

Thanks again.

Regards,
Yury
