### PR TITLE
Really trivial Makefile change to make the initial installation easier

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,7 @@
 COUCH_ROOT = /opt/couchbase-server
 COUCHDB_ERLANG_LIB = $(COUCH_ROOT)/lib/couchdb/erlang/lib/couch-1.0.2
 COUCHDB_LOCALD = $(COUCH_ROOT)/etc/couchdb/local.d
+COUCHDB_INIT_SCRIPT = /etc/init.d/couchdb
 
 
 any:
@@ -16,7 +17,7 @@ test: clean
 install: compile
 	sudo cp fb_auth.beam $(COUCHDB_ERLANG_LIB)/ebin/
 	sudo cp fb_auth.ini $(COUCHDB_LOCALD)
-	sudo /etc/init.d/couchdb restart
+	sudo $(COUCHDB_INIT_SCRIPT) restart
 
 compile: clean
 	erlc -I $(COUCHDB_ERLANG_LIB)/include/ fb_auth.erl

--- a/README.md
+++ b/README.md
@@ -43,8 +43,7 @@ Build
 
 There is an unsophisticated Makefile with targets for _test_ (requires eunit), _compile_ and _install_. 
 
-In order to compile and install this module you might have to edit the Makefile and change one or more of _COUCH\_ROOT_, _\_COUCHDB\_ERLANG\_LIB_ 
-and _COUCHDB\_LOCALD_ values to point to the appropriate directories within your couchdb installation
+In order to compile and install this module you might have to edit the Makefile and change one or more of _COUCH\_ROOT_, _\_COUCHDB\_ERLANG\_LIB_, _COUCHDB\_LOCALD_ and _COUCHDB\_INIT\_SCRIPT_ values to point to the appropriate directories and file within your couchdb installation.
 
 
 Installation


### PR DESCRIPTION
Commit description:

Make the init path script configurable 

In the default couchbase-server installation for example, the path
should be /etc/init.d/couchbase-server.
